### PR TITLE
Replace hardcoded PDK paths with environment variable based paths in gmid .py scripts for NMOS and PMOS

### DIFF
--- a/modules/module_0_foundations/sg13_nmos_lv.py
+++ b/modules/module_0_foundations/sg13_nmos_lv.py
@@ -1,7 +1,14 @@
+import os
 from mosplot.lookup_table_generator.simulators import NgspiceSimulator, HspiceSimulator
 from mosplot.lookup_table_generator import LookupTableGenerator, TransistorSweep
 # One of `include_paths` or `lib_mappings` must be specified.
 # The rest are optional.
+
+# Read environment variables to build model path
+PDK_ROOT = os.environ["PDK_ROOT"]
+PDK = os.environ["PDK"]
+
+model_path = os.path.join(PDK_ROOT, PDK, "libs.tech/ngspice/models/cornerMOSlv.lib")
 
 ngspice = NgspiceSimulator(
     # Provide path to simulator if simulator is not in system path.
@@ -15,8 +22,8 @@ ngspice = NgspiceSimulator(
 
 
     # Files to include with `.LIB`.
-    lib_mappings = [
-        ("/home/pedersen/IHP-Open-PDK/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib", " mos_tt") # Put your own path to the corner lib
+      lib_mappings = [
+    (model_path, "mos_tt")
     ],
 
     # If the transistor is defined inside a subcircuit in

--- a/modules/module_0_foundations/sg13_pmos_lv.py
+++ b/modules/module_0_foundations/sg13_pmos_lv.py
@@ -1,7 +1,14 @@
+import os
 from mosplot.lookup_table_generator.simulators import NgspiceSimulator, HspiceSimulator
 from mosplot.lookup_table_generator import LookupTableGenerator, TransistorSweep
 # One of `include_paths` or `lib_mappings` must be specified.
 # The rest are optional.
+
+# Read environment variables to build model path
+PDK_ROOT = os.environ["PDK_ROOT"]
+PDK = os.environ["PDK"]
+
+model_path = os.path.join(PDK_ROOT, PDK, "libs.tech/ngspice/models/cornerMOSlv.lib")
 
 ngspice = NgspiceSimulator(
     # Provide path to simulator if simulator is not in system path.
@@ -15,8 +22,8 @@ ngspice = NgspiceSimulator(
 
 
     # Files to include with `.LIB`.
-    lib_mappings = [
-        ("/home/pedersen/IHP-Open-PDK/ihp-sg13g2/libs.tech/ngspice/models/cornerMOSlv.lib", " mos_tt") # Put your own path to the corner lib
+      lib_mappings = [
+    (model_path, "mos_tt")
     ],
 
     # If the transistor is defined inside a subcircuit in


### PR DESCRIPTION
### Summary

This PR replaces hardcoded PDK model paths in sg13_nmos_lv.py with environment variable-based paths (`PDK_ROOT` and `PDK`) for improved portability across systems and user setups.

### Changes made
- Added `import os` and read environment variables `PDK_ROOT` and `PDK`.
- Replaced hardcoded `model_path` with a dynamic construction using `os.path.join`.
- Updated `lib_mappings` to use the dynamic path.

### Rationale

Using environment variables instead of hardcoded paths ensures:
- Scripts work on any system without modification.
- Easier onboarding for students and contributors.
- Cleaner, more maintainable code.

Please review and let me know if any further adjustments are needed.
