### PR TITLE
Pull Request: Fix notebook path typo in README instructions

### DIFF
--- a/modules/module_0_foundations/foundations.md
+++ b/modules/module_0_foundations/foundations.md
@@ -99,7 +99,7 @@ The scripts that was made for generating the LUTs can be found as:
 4. **Launch the GMID GUI**  
    From the same directory, launch the Jupyter notebook:  
    ```bash
-   jupyter lab _gmid_test.ipynb
+   jupyter lab ../gmid_test.ipynb
    ```
    This notebook will open a GUI for exploring the GMID lookup tables, which should look like the following (make sure the paths match yours accordingly):
 


### PR DESCRIPTION
### **Summary**

This PR fixes a **path typo** in the current README:

🔴 **Current instruction:**

```bash
jupyter lab _gmid_test.ipynb
```

✅ **Proposed correction:**

```bash
jupyter lab ../gmid_test.ipynb
```

### **Reason**

The notebook `gmid_test.ipynb` is located **one directory above** the current working directory (`scripting/`) as per repo structure.

Using `_gmid_test.ipynb` (with underscore) throws a **FileNotFoundError**, leading to user confusion during initial setup.


### **Impact**

✅ Enables users to:

* Successfully launch the provided Jupyter notebook
* Follow setup instructions **without interruption**