### PR TITLE
Remove modulo operator from sar logic

### DIFF
--- a/modules/module_3_8_bit_SAR_ADC/part_2_digital_comps/algorithm/verilog/sar_logic.v
+++ b/modules/module_3_8_bit_SAR_ADC/part_2_digital_comps/algorithm/verilog/sar_logic.v
@@ -1,33 +1,26 @@
 module sar_logic (
-    input wire clk, 
+    input wire clk,
     input wire Op,
     input wire En,
     input wire Om,
     input wire rst,
-    output reg [6:0] B,   // 7-bit
-    output reg [6:0] BN,  // 7-bit
+    output wire [7:0] B,  // 8-bit
+    output reg [7:0] BN,  // 8-bit
     output reg [7:0] D    // 8-bit
 );
 
-reg [3:0] counter = 4'b0000; // 4-bit counter
+  reg [3:0] counter; // 3-bit counter
+  assign B = D;
 
-always @(posedge clk) begin
+  always @(posedge clk) begin
     if (rst) begin
-        B <= 7'b0000000;
-        BN <= 7'b0000000;
-        D <= 8'b00000000;
-        counter <= 4'b0000;
-    end else if (En && (Op ^ Om)) begin
-        if (counter < 7) begin 
-            D <= D | ({7'b0, Op} << counter);
-              
-            B[counter % 7] <= (Op) ? 1'b1 : 1'b0;
-            BN[counter % 7] <= (Om) ? 1'b1 : 1'b0;
-
-            counter <= counter + 1'b1;
-        end
+      BN <= 8'b0000000;
+      D <= 8'b00000000;
+      counter <= 4'b0000;
+    end else if (En && (Op ^ Om) && ~(counter==8)) begin
+      D[counter[2:0]] <= Op;
+      BN[counter[2:0]] <= Om;
+      counter <= counter + 1'b1;
     end
-end
-
+  end
 endmodule
-

--- a/modules/module_3_8_bit_SAR_ADC/part_2_digital_comps/algorithm/verilog/sar_logic_tb.v
+++ b/modules/module_3_8_bit_SAR_ADC/part_2_digital_comps/algorithm/verilog/sar_logic_tb.v
@@ -10,8 +10,8 @@ module sar_logic_tb();
     reg En;
 
     // Outputs
-    wire [6:0] B;
-    wire [6:0] BN;
+    wire [7:0] B;
+    wire [7:0] BN;
     wire [7:0] D;
 
     // Instantiate the SAR Logic module
@@ -46,14 +46,85 @@ module sar_logic_tb();
         En = 1'b1;
         Op = 1'b1;
         Om = 1'b0;
-        
+
         // Apply reset again
-        #80 rst = 1'b1;
+        #100 rst = 1'b1;
         #10 rst = 1'b0;
         Op = 1'b0;
         Om = 1'b1;
 
-        #70 rst = 1'b1;
+        #50 rst = 1'b1;
+	#10 rst = 1'b0;
+        En = 1'b1;
+        Op = 1'b1;
+        Om = 1'b0;
+
+        #10 Op = 1'b0;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+
+        #50 rst = 1'b1;
+	#10 rst = 1'b0;
+        En = 1'b1;
+	Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
+
+	#10 Op = 1'b1;
+        Om = 1'b0;
+
+	#10 Op = 1'b0;
+        Om = 1'b1;
 
         // End of simulation
         #100 $finish;


### PR DESCRIPTION
Modulo operator is usualy heavy and shouldn't be normaly used. This commit removes it. Additionaly a bug with number of used bits is fixed.

Author: Kuba Nowak